### PR TITLE
Removed cross origin code properties from script tag for socket.io.js

### DIFF
--- a/netperf/dashboard/html/dashboard.html
+++ b/netperf/dashboard/html/dashboard.html
@@ -9,7 +9,7 @@ See the file LICENSE for full license details.
 		<link rel="icon" type="image/png" href="images/speedometer.png">
 		<link rel="stylesheet" href="styles/dashboard.css">
 		<title>Network Performance Monitor</title>
-		<script src="//cdnjs.cloudflare.com/ajax/libs/socket.io/2.2.0/socket.io.js" integrity="sha256-yr4fRk/GU1ehYJPAs8P4JlTgu0Hdsp4ZKrx8bDEDC3I=" crossorigin="anonymous"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.2.0/socket.io.js"></script>
 		<script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.1.4/Chart.bundle.js"></script>
 		<script src="scripts/dashboard.js"></script>
 	</head>


### PR DESCRIPTION
Fixes #23 Addresses CORS errors when loading dashboard under Safari that was stopping the graphs from being rendered.